### PR TITLE
Fix Clerk middleware configuration

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,13 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware({
-  publicRoutes: ["/", "/sign-in(.*)", "/sign-up(.*)"],
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isPublicRoute(req)) {
+    return;
+  }
+
+  await auth.protect();
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
- update the Clerk middleware to define public routes with `createRouteMatcher`
- protect non-public requests by awaiting `auth.protect()` inside the middleware handler

## Testing
- npm run build *(fails: MONGODB_URI not set in .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fd1194c88328949345afae50d71f